### PR TITLE
Relax dependency on zxing-wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
   },
   "dependencies": {
     "@types/dom-webcodecs": "^0.1.9",
-    "zxing-wasm": "1.0.0-rc.4"
+    "zxing-wasm": "^1.0.0-rc.4"
   }
 }


### PR DESCRIPTION
By relaxing the dependency definition, we are able to also use the latest version of `zxing-wasm` (currently v1.0.0-rc.6) in projects using `barcode-detector`.

Thanks!