### PR TITLE
fix: image bitmap source type detection across iframes

### DIFF
--- a/.changeset/rich-cougars-laugh.md
+++ b/.changeset/rich-cougars-laugh.md
@@ -1,0 +1,5 @@
+---
+"barcode-detector": patch
+---
+
+Fix image bitmap source type detection across iframes.

--- a/package.json
+++ b/package.json
@@ -90,26 +90,26 @@
     "@changesets/cli": "^2.27.9",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
-    "@types/node": "^22.7.4",
+    "@types/node": "^22.7.5",
     "@vitest/browser": "^2.1.2",
     "@vitest/coverage-istanbul": "^2.1.2",
     "@vitest/ui": "^2.1.2",
     "concurrently": "^9.0.1",
     "http-server": "^14.1.1",
     "lint-staged": "^15.2.10",
-    "playwright": "^1.47.2",
+    "playwright": "^1.48.0",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "simple-git-hooks": "^2.11.1",
     "start-server-and-test": "^2.0.8",
     "tsx": "^4.19.1",
-    "typescript": "^5.6.2",
+    "typescript": "^5.6.3",
     "vite": "^5.4.8",
     "vitest": "^2.1.2"
   },
   "dependencies": {
-    "@types/dom-webcodecs": "^0.1.12",
+    "@types/dom-webcodecs": "^0.1.13",
     "zxing-wasm": "1.2.14"
   },
-  "packageManager": "pnpm@9.12.0+sha512.4abf725084d7bcbafbd728bfc7bee61f2f791f977fd87542b3579dcb23504d170d46337945e4c66485cd12d588a0c0e570ed9c477e7ccdd8507cf05f3f92eaca"
+  "packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@types/dom-webcodecs':
-        specifier: ^0.1.12
-        version: 0.1.12
+        specifier: ^0.1.13
+        version: 0.1.13
       zxing-wasm:
         specifier: 1.2.14
         version: 1.2.14
@@ -23,16 +23,16 @@ importers:
         version: 2.27.9
       '@commitlint/cli':
         specifier: ^19.5.0
-        version: 19.5.0(@types/node@22.7.4)(typescript@5.6.2)
+        version: 19.5.0(@types/node@22.7.5)(typescript@5.6.3)
       '@commitlint/config-conventional':
         specifier: ^19.5.0
         version: 19.5.0
       '@types/node':
-        specifier: ^22.7.4
-        version: 22.7.4
+        specifier: ^22.7.5
+        version: 22.7.5
       '@vitest/browser':
         specifier: ^2.1.2
-        version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4))(vitest@2.1.2)
+        version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.48.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5))(vitest@2.1.2)
       '@vitest/coverage-istanbul':
         specifier: ^2.1.2
         version: 2.1.2(vitest@2.1.2)
@@ -49,8 +49,8 @@ importers:
         specifier: ^15.2.10
         version: 15.2.10
       playwright:
-        specifier: ^1.47.2
-        version: 1.47.2
+        specifier: ^1.48.0
+        version: 1.48.0
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -67,14 +67,14 @@ importers:
         specifier: ^4.19.1
         version: 4.19.1
       typescript:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^5.6.3
+        version: 5.6.3
       vite:
         specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.7.4)
+        version: 5.4.8(@types/node@22.7.5)
       vitest:
         specifier: ^2.1.2
-        version: 2.1.2(@types/node@22.7.4)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.2))
+        version: 2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.3))
 
 packages:
 
@@ -819,8 +819,8 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
-  '@types/dom-webcodecs@0.1.12':
-    resolution: {integrity: sha512-vEkwKEr0xAO2xwNNkYhaltT7jMGjrgAbfpRR3qKRN7eW3B7R7O5fm1scx2OKBY6wMACgjCewhu+ljbCdudY+5A==}
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
 
   '@types/emscripten@1.39.13':
     resolution: {integrity: sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==}
@@ -837,8 +837,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.7.4':
-    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
@@ -1992,13 +1992,13 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  playwright-core@1.47.2:
-    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==}
+  playwright-core@1.48.0:
+    resolution: {integrity: sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.47.2:
-    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
+  playwright@1.48.0:
+    resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2353,8 +2353,8 @@ packages:
     resolution: {integrity: sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==}
     engines: {node: '>=16'}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2848,11 +2848,11 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@commitlint/cli@19.5.0(@types/node@22.7.4)(typescript@5.6.2)':
+  '@commitlint/cli@19.5.0(@types/node@22.7.5)(typescript@5.6.3)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.5.0
-      '@commitlint/load': 19.5.0(@types/node@22.7.4)(typescript@5.6.2)
+      '@commitlint/load': 19.5.0(@types/node@22.7.5)(typescript@5.6.3)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.0
@@ -2899,15 +2899,15 @@ snapshots:
       '@commitlint/rules': 19.5.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.5.0(@types/node@22.7.4)(typescript@5.6.2)':
+  '@commitlint/load@19.5.0(@types/node@22.7.5)(typescript@5.6.3)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
       '@commitlint/resolve-extends': 19.5.0
       '@commitlint/types': 19.5.0
       chalk: 5.3.0
-      cosmiconfig: 9.0.0(typescript@5.6.2)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.4)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2)
+      cosmiconfig: 9.0.0(typescript@5.6.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -3115,7 +3115,7 @@ snapshots:
       '@inquirer/figures': 1.0.5
       '@inquirer/type': 1.5.2
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-spinners: 2.9.2
@@ -3286,11 +3286,11 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/cookie@0.6.0': {}
 
-  '@types/dom-webcodecs@0.1.12': {}
+  '@types/dom-webcodecs@0.1.13': {}
 
   '@types/emscripten@1.39.13': {}
 
@@ -3300,11 +3300,11 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.7.4':
+  '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3314,20 +3314,20 @@ snapshots:
 
   '@types/wrap-ansi@3.0.0': {}
 
-  '@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4))(vitest@2.1.2)':
+  '@vitest/browser@2.1.2(@vitest/spy@2.1.2)(playwright@1.48.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5))(vitest@2.1.2)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.2))(vite@5.4.8(@types/node@22.7.4))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.3))(vite@5.4.8(@types/node@22.7.5))
       '@vitest/utils': 2.1.2
       magic-string: 0.30.11
-      msw: 2.3.5(typescript@5.6.2)
+      msw: 2.3.5(typescript@5.6.3)
       sirv: 2.0.4
       tinyrainbow: 1.2.0
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.2))
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.3))
       ws: 8.18.0
     optionalDependencies:
-      playwright: 1.47.2
+      playwright: 1.48.0
     transitivePeerDependencies:
       - '@vitest/spy'
       - bufferutil
@@ -3347,7 +3347,7 @@ snapshots:
       magicast: 0.3.4
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.2))
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -3358,14 +3358,14 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.2))(vite@5.4.8(@types/node@22.7.4))':
+  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.3))(vite@5.4.8(@types/node@22.7.5))':
     dependencies:
       '@vitest/spy': 2.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
-      msw: 2.3.5(typescript@5.6.2)
-      vite: 5.4.8(@types/node@22.7.4)
+      msw: 2.3.5(typescript@5.6.3)
+      vite: 5.4.8(@types/node@22.7.5)
 
   '@vitest/pretty-format@2.1.2':
     dependencies:
@@ -3395,7 +3395,7 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.9
       tinyrainbow: 1.2.0
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.2))
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.3))
 
   '@vitest/utils@2.1.2':
     dependencies:
@@ -3618,21 +3618,21 @@ snapshots:
 
   corser@2.0.1: {}
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.4)(cosmiconfig@9.0.0(typescript@5.6.2))(typescript@5.6.2):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@22.7.5)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
-      '@types/node': 22.7.4
-      cosmiconfig: 9.0.0(typescript@5.6.2)
+      '@types/node': 22.7.5
+      cosmiconfig: 9.0.0(typescript@5.6.3)
       jiti: 1.21.6
-      typescript: 5.6.2
+      typescript: 5.6.3
 
-  cosmiconfig@9.0.0(typescript@5.6.2):
+  cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.6.3
 
   cross-spawn@5.1.0:
     dependencies:
@@ -4319,7 +4319,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.3.5(typescript@5.6.2):
+  msw@2.3.5(typescript@5.6.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -4339,7 +4339,7 @@ snapshots:
       type-fest: 4.25.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.6.3
 
   mute-stream@1.0.0: {}
 
@@ -4458,11 +4458,11 @@ snapshots:
 
   pify@4.0.1: {}
 
-  playwright-core@1.47.2: {}
+  playwright-core@1.48.0: {}
 
-  playwright@1.47.2:
+  playwright@1.48.0:
     dependencies:
-      playwright-core: 1.47.2
+      playwright-core: 1.48.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -4792,7 +4792,7 @@ snapshots:
 
   type-fest@4.25.0: {}
 
-  typescript@5.6.2: {}
+  typescript@5.6.3: {}
 
   undici-types@6.19.8: {}
 
@@ -4819,12 +4819,12 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  vite-node@2.1.2(@types/node@22.7.4):
+  vite-node@2.1.2(@types/node@22.7.5):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6
       pathe: 1.1.2
-      vite: 5.4.8(@types/node@22.7.4)
+      vite: 5.4.8(@types/node@22.7.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4836,19 +4836,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.8(@types/node@22.7.4):
+  vite@5.4.8(@types/node@22.7.5):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       fsevents: 2.3.3
 
-  vitest@2.1.2(@types/node@22.7.4)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.2)):
+  vitest@2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(@vitest/ui@2.1.2)(msw@2.3.5(typescript@5.6.3)):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.2))(vite@5.4.8(@types/node@22.7.4))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.3.5(typescript@5.6.3))(vite@5.4.8(@types/node@22.7.5))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2
@@ -4863,12 +4863,12 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.7.4)
-      vite-node: 2.1.2(@types/node@22.7.4)
+      vite: 5.4.8(@types/node@22.7.5)
+      vite-node: 2.1.2(@types/node@22.7.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.7.4
-      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.47.2)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4))(vitest@2.1.2)
+      '@types/node': 22.7.5
+      '@vitest/browser': 2.1.2(@vitest/spy@2.1.2)(playwright@1.48.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5))(vitest@2.1.2)
       '@vitest/ui': 2.1.2(vitest@2.1.2)
     transitivePeerDependencies:
       - less

--- a/src/BarcodeDetector.ts
+++ b/src/BarcodeDetector.ts
@@ -1,5 +1,6 @@
 import {
   type ReadResult,
+  type ReaderOptions,
   type ZXingReaderModule,
   getZXingModule,
   readBarcodesFromImageData,
@@ -111,24 +112,26 @@ export class BarcodeDetector extends EventTarget {
         return [];
       }
       let zxingReadOutputs: ReadResult[];
+      const readerOptions: ReaderOptions = {
+        tryHarder: true,
+        // https://github.com/Sec-ant/barcode-detector/issues/91
+        returnCodabarStartEnd: true,
+        formats: this.#formats.map((format) => formatMap.get(format)!),
+      };
       try {
         // if `imageDataOrBlob` is still a blob
         // it means we cannot handle it with our js code
         // so we directly feed it to the wasm module
         if (isBlob(imageDataOrBlob)) {
-          zxingReadOutputs = await readBarcodesFromImageFile(imageDataOrBlob, {
-            tryHarder: true,
-            // https://github.com/Sec-ant/barcode-detector/issues/91
-            returnCodabarStartEnd: true,
-            formats: this.#formats.map((format) => formatMap.get(format)!),
-          });
+          zxingReadOutputs = await readBarcodesFromImageFile(
+            imageDataOrBlob,
+            readerOptions,
+          );
         } else {
-          zxingReadOutputs = await readBarcodesFromImageData(imageDataOrBlob, {
-            tryHarder: true,
-            // https://github.com/Sec-ant/barcode-detector/issues/91
-            returnCodabarStartEnd: true,
-            formats: this.#formats.map((format) => formatMap.get(format)!),
-          });
+          zxingReadOutputs = await readBarcodesFromImageData(
+            imageDataOrBlob,
+            readerOptions,
+          );
         }
       } catch (e) {
         // we need this information to debug

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,7 +159,10 @@ function isImageBitmap(
   image: ImageBitmapSourceWebCodecs,
 ): image is ImageBitmap {
   try {
-    return image instanceof ImageBitmap;
+    return (
+      image instanceof ImageBitmap ||
+      Object.prototype.toString.call(image) === "[object ImageBitmap]"
+    );
   } catch {
     return false;
   }
@@ -169,7 +172,10 @@ function isOffscreenCanvas(
   image: ImageBitmapSourceWebCodecs,
 ): image is OffscreenCanvas {
   try {
-    return image instanceof OffscreenCanvas;
+    return (
+      image instanceof OffscreenCanvas ||
+      Object.prototype.toString.call(image) === "[object OffscreenCanvas]"
+    );
   } catch {
     return false;
   }
@@ -177,7 +183,10 @@ function isOffscreenCanvas(
 
 function isVideoFrame(image: ImageBitmapSourceWebCodecs): image is VideoFrame {
   try {
-    return image instanceof VideoFrame;
+    return (
+      image instanceof VideoFrame ||
+      Object.prototype.toString.call(image) === "[object VideoFrame]"
+    );
   } catch {
     return false;
   }
@@ -185,7 +194,10 @@ function isVideoFrame(image: ImageBitmapSourceWebCodecs): image is VideoFrame {
 
 export function isBlob(image: ImageBitmapSourceWebCodecs): image is Blob {
   try {
-    return image instanceof Blob;
+    return (
+      image instanceof Blob ||
+      Object.prototype.toString.call(image) === "[object Blob]"
+    );
   } catch {
     return false;
   }
@@ -193,7 +205,10 @@ export function isBlob(image: ImageBitmapSourceWebCodecs): image is Blob {
 
 function isImageData(image: ImageBitmapSourceWebCodecs): image is ImageData {
   try {
-    return image instanceof ImageData;
+    return (
+      image instanceof ImageData ||
+      Object.prototype.toString.call(image) === "[object ImageData]"
+    );
   } catch {
     return false;
   }
@@ -417,10 +432,10 @@ function isImageBitmapClosed(imageBitmap: ImageBitmap) {
 }
 
 export function addPrefixToExceptionOrError(e: unknown, prefix: string) {
-  if (e instanceof DOMException) {
+  if (isDOMException(e)) {
     return new DOMException(`${prefix}: ${e.message}`, e.name);
   }
-  if (e instanceof Error) {
+  if (isError(e)) {
     return new (
       e.constructor as
         | ErrorConstructor
@@ -432,4 +447,17 @@ export function addPrefixToExceptionOrError(e: unknown, prefix: string) {
     )(`${prefix}: ${e.message}`);
   }
   return new Error(`${prefix}: ${e}`);
+}
+
+function isDOMException(e: unknown): e is DOMException {
+  return (
+    e instanceof DOMException ||
+    Object.prototype.toString.call(e) === "[object DOMException]"
+  );
+}
+
+function isError(e: unknown): e is Error {
+  return (
+    e instanceof Error || Object.prototype.toString.call(e) === "[object Error]"
+  );
 }

--- a/tests/barcode-detection.spec.ts
+++ b/tests/barcode-detection.spec.ts
@@ -5,6 +5,7 @@ import { BarcodeDetector } from "../src/index.js";
 import {
   drawImageToCanvas,
   getHTMLImage,
+  getIframeCanvas,
   getIframeHtmlImage,
   getIframeVideo,
   getVideo,
@@ -177,17 +178,6 @@ describe("BarcodeDetector.detect() accepts", () => {
     areCatsAndDogs(detectionResult);
   });
 
-  test("BarcodeDetector.detect() accepts a uint16 storage format ImageData", async () => {
-    // TODO: check the runtime support for storageFormat
-    const imgUint16 = new ImageData(1024, 1024, {
-      storageFormat: "uint16",
-    });
-
-    const bacodeDetector = new BarcodeDetector();
-
-    await bacodeDetector.detect(imgUint16);
-  });
-
   test("BarcodeDetector.detect() accepts an iframe HTMLImageElement", async () => {
     const image = await getIframeHtmlImage();
     const barcodeDetector = new BarcodeDetector();
@@ -199,6 +189,15 @@ describe("BarcodeDetector.detect() accepts", () => {
     const video = await getIframeVideo();
     const barcodeDetector = new BarcodeDetector();
     const detectionResult = await barcodeDetector.detect(video);
+    areCatsAndDogs(detectionResult);
+  });
+
+  test("BarcodeDetector.detect() accepts an iframe ImageData", async () => {
+    const canvas = await getIframeCanvas();
+    const barcodeDetector = new BarcodeDetector();
+    const detectionResult = await barcodeDetector.detect(
+      canvas.getContext("2d")!.getImageData(0, 0, canvas.width, canvas.height)!,
+    );
     areCatsAndDogs(detectionResult);
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -127,6 +127,43 @@ export async function getIframeVideo(
   });
 }
 
+export async function getIframeCanvas(
+  src = new URL("./resources/cats-dogs.png", import.meta.url).href,
+) {
+  const image = await getHTMLImage(src);
+  return await new Promise<HTMLCanvasElement>((resolve, reject) => {
+    const iframe = document.createElement("iframe");
+    iframe.addEventListener("load", () => {
+      const iframeCanvas = iframe.contentDocument?.querySelector("canvas");
+      if (iframeCanvas) {
+        iframeCanvas.width = image.width;
+        iframeCanvas.height = image.height;
+        (
+          iframeCanvas.getContext("2d") as
+            | CanvasRenderingContext2D
+            | OffscreenCanvasRenderingContext2D
+        ).drawImage(image, 0, 0, image.width, image.height);
+        resolve(iframeCanvas);
+      } else {
+        reject(
+          new DOMException("Canvas not found in iframe!", "NotFoundError"),
+        );
+      }
+    });
+    iframe.addEventListener("error", (error) => {
+      reject([error, iframe] as const);
+    });
+    iframe.srcdoc = `<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <canvas></canvas>
+  </body>
+</html>`;
+    document.body.appendChild(iframe);
+  });
+}
+
 async function waitForNFrames(count: number) {
   if (count <= 0) {
     return Promise.reject(new TypeError("count should be greater than 0!"));


### PR DESCRIPTION
A follow-up fix of #110, see https://github.com/Sec-ant/barcode-detector/issues/110#issuecomment-2403003126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced barcode detection for bitmap images within iframes.
	- Introduced a helper function to improve testing of iframe-based image processing.
	- Streamlined barcode detection options for improved maintainability.

- **Bug Fixes**
	- Improved type checks for various image-related entities, enhancing error handling and type safety.

- **Tests**
	- Added new tests to validate barcode detection functionality with iframe images.
	- Streamlined the test suite by removing outdated test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->